### PR TITLE
Add dynamic text contrast calculation for timeline/timetable

### DIFF
--- a/css/frontend-common.css
+++ b/css/frontend-common.css
@@ -15,6 +15,7 @@
    --kompassi-fg-invert: hsla(0deg, 0%, 100%, 100%);
    --kompassi-bg: rgb(255, 255, 255); /* Need to use rgb() value! */
    --kompassi-bg-alt: hsl(var(--kompassi-hue), 30%, 97%);
+   --kompassi-lightness-threshold: 0.8; /* For accessibility, 0.6 is the optimal value */
 
    /*  Palette  */
    --kompassi-palette-0: hsl(var(--kompassi-hue), 20%, 10%);

--- a/css/schedule.css
+++ b/css/schedule.css
@@ -628,7 +628,7 @@ summary {
 		display: inline-block;
 		background-color: var(--kompassi-program-color,var(--kompassi-program-color-default));
 		background-image: linear-gradient(to bottom,rgba(0 0 0 25%),rgba(0 0 0 15%));
-		color: #fff;
+		color: oklch(from var(--kompassi-program-color,var(--kompassi-program-color-default)) calc((var(--kompassi-lightness-threshold) - l) * 1000) 0 0);
 
 		z-index: 5;
 		white-space: nowrap;
@@ -839,7 +839,7 @@ summary {
 		padding: var(--kompassi-schedule-timetable-program-padding);
 		background-color: var(--kompassi-program-color,var(--kompassi-program-color-default));
 		background-image: linear-gradient(to bottom,rgba(0 0 0 25%),rgba(0 0 0 15%));
-		color: #fff;
+		color: oklch(from var(--kompassi-program-color,var(--kompassi-program-color-default)) calc((var(--kompassi-lightness-threshold) - l) * 1000) 0 0);
 		box-shadow: var(--kompassi-box-shadow);
 		z-index: 2;
 		scroll-snap-align: start;


### PR DESCRIPTION
Timeline and timetable views have a contrast issue when the program is set to have a lighter color:

<img width="570" height="254" alt="Screenshot_20260715_151416" src="https://github.com/user-attachments/assets/317335dc-da83-413f-81d0-1bc5bb1e6306" />

This PR addresses the issue by dynamically calculating the color value from the program background and a threshold.

<img width="570" height="254" alt="Screenshot_20260715_151424" src="https://github.com/user-attachments/assets/59d858ea-0351-4d11-af7a-05683ec69f79" />

Technically speaking (based on WCAG) 0.6 seems to be the best threshold value for maximized accessibility, but I've kept it 0.8 to keep it more aligned with the theme.

It uses the relative color CSS syntax which is included in the Baseline 2024 browser compatibility set.